### PR TITLE
Fix for window.bind('resize') loop in old IE

### DIFF
--- a/grids.js
+++ b/grids.js
@@ -62,10 +62,14 @@
   $.fn.responsiveEqualHeightGrid = function() {
     var _this = this;
     function syncHeights() {
-      var cols = _this.detectGridColumns();
-      _this.equalHeightGrid(cols);  
+        var cols = _this.detectGridColumns();
+        _this.equalHeightGrid(cols);
+        setTimeout(resizeListener,100);
+      }
+    var resizeListener = function(){
+      $(window).one('resize load', syncHeights);
     }
-    $(window).bind('resize load', syncHeights);
+    resizeListener();
     syncHeights();
     return this;
   };


### PR DESCRIPTION
As documented here: https://stackoverflow.com/questions/1852751/window-resize-event-firing-in-internet-explorer
Fixes #6
