### PR TITLE
Added callback

### DIFF
--- a/grids.js
+++ b/grids.js
@@ -61,7 +61,7 @@
     /**
      * Ensure equal heights now, on ready, load and resize.
      */
-    $.fn.responsiveEqualHeightGrid = function() {
+    $.fn.responsiveEqualHeightGrid = function(callback) {
         var _this = this;
 
         function syncHeights() {
@@ -70,6 +70,7 @@
         }
         $(window).bind('resize load', syncHeights);
         syncHeights();
+	callback();
         return this;
     };
 


### PR DESCRIPTION
Sometimes the grid isn't created ok, so I added a callback to invoke a function to correct the grid without resizing, I use as follows:

$('.element').responsiveEqualHeightGrid(function(){$(window).resize();}); 

Cheers!