### PR TITLE
Fixed problem when some elements in the grid are invisible.

### DIFF
--- a/grids.js
+++ b/grids.js
@@ -49,17 +49,15 @@
      */
     $.fn.detectGridColumns = function() {
         var offset = 0,
-            cols = 0;
-        this.each(function(i, elem) {
+            cols = 0,
+            $tiles = this.filter(':visible');
+        $tiles.each(function(i, elem) {
             var elemOffset = $(elem).offset().top;
-	        var elemVisible = $(elem).is(":visible");
-            if (elemVisible) {
-                if (offset === 0 || elemOffset === offset) {
-                    cols++;
-                    offset = elemOffset;
-                } else {
-                    return false;
-                }
+	        if (offset === 0 || elemOffset === offset) {
+				cols++;
+                offset = elemOffset;
+            } else {
+				return false;
             }
         });
         return cols;

--- a/grids.js
+++ b/grids.js
@@ -53,11 +53,11 @@
             $tiles = this.filter(':visible');
         $tiles.each(function(i, elem) {
             var elemOffset = $(elem).offset().top;
-	        if (offset === 0 || elemOffset === offset) {
-				cols++;
+            if (offset === 0 || elemOffset === offset) {
+                cols++;
                 offset = elemOffset;
             } else {
-				return false;
+                return false;
             }
         });
         return cols;

--- a/grids.js
+++ b/grids.js
@@ -30,7 +30,7 @@
      * Create a grid of equal height elements.
      */
     $.fn.equalHeightGrid = function(columns) {
-        var $tiles = this;
+        var $tiles = this.filter(':visible');
         $tiles.css('height', 'auto');
         for (var i = 0; i < $tiles.length; i++) {
             if (i % columns === 0) {
@@ -52,11 +52,14 @@
             cols = 0;
         this.each(function(i, elem) {
             var elemOffset = $(elem).offset().top;
-            if (offset === 0 || elemOffset === offset) {
-                cols++;
-                offset = elemOffset;
-            } else {
-                return false;
+	        var elemVisible = $(elem).is(":visible");
+            if (elemVisible) {
+                if (offset === 0 || elemOffset === offset) {
+                    cols++;
+                    offset = elemOffset;
+                } else {
+                    return false;
+                }
             }
         });
         return cols;


### PR DESCRIPTION
There was a problem when some elements in the grid are invisible. 
Please, look at this fiddle: http://jsfiddle.net/mLxpp7mt/

When first column is hidden, height of second (now first column) is miscalculated, because invisible column is counted in detectGridColumns.